### PR TITLE
Add paho to loggers in manifest.json

### DIFF
--- a/custom_components/eaton_ups_mqtt/manifest.json
+++ b/custom_components/eaton_ups_mqtt/manifest.json
@@ -12,5 +12,8 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/lnagel/hass-eaton-ups-mqtt/issues",
+  "loggers": [
+    "paho"
+  ],
   "version": "0.2.1"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled dedicated logging for the MQTT client to improve visibility into connection and messaging events.
  * Provides clearer diagnostics in logs, aiding troubleshooting of MQTT connectivity and message flow.
  * No changes to configuration or device behavior; normal operation remains unaffected.
  * Useful for support scenarios where detailed MQTT logging is required without altering runtime functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->