### PR TITLE
Add sensor device support (temperature, humidity, dry contacts)

### DIFF
--- a/custom_components/eaton_ups_mqtt/api.py
+++ b/custom_components/eaton_ups_mqtt/api.py
@@ -227,6 +227,7 @@ class EatonUpsMqttClient:
             topic=[
                 ("mbdetnrs/+/managers/#", 0),
                 ("mbdetnrs/+/powerDistributions/#", 0),
+                ("mbdetnrs/+/sensors/#", 0),
             ]
         )
 

--- a/custom_components/eaton_ups_mqtt/binary_sensor.py
+++ b/custom_components/eaton_ups_mqtt/binary_sensor.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import re
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.helpers.entity import EntityCategory
 
 from .entity import EatonUpsEntity
 
@@ -255,6 +257,59 @@ def _generate_outlet_binary_descriptions(
     )
 
 
+ENV_DIGITAL_INPUT_PATTERN = re.compile(
+    r"^sensors/devices/([^/]+)/channels/digitalInputs/([^/]+)/measures$"
+)
+ENV_COMM_STATUS_PATTERN = re.compile(r"^sensors/devices/([^/]+)/communicationStatus$")
+
+
+def _get_env_channel_name(
+    data: dict[str, Any], channel_type: str, device_id: str, channel_id: str
+) -> str:
+    """Get human-readable channel name from identification topic."""
+    id_key = (
+        f"sensors/devices/{device_id}"
+        f"/channels/{channel_type}/{channel_id}/identification"
+    )
+    id_data = data.get(id_key, {})
+    if isinstance(id_data, dict):
+        return id_data.get("name") or id_data.get("physicalName") or channel_id
+    return channel_id
+
+
+def _get_env_device_name(data: dict[str, Any], device_id: str) -> str:
+    """Get human-readable device name from identification topic."""
+    id_key = f"sensors/devices/{device_id}/identification"
+    id_data = data.get(id_key, {})
+    if isinstance(id_data, dict):
+        return id_data.get("name") or id_data.get("physicalName") or device_id
+    return device_id
+
+
+def _generate_env_digital_input_description(
+    device_id: str, channel_id: str, channel_name: str
+) -> BinarySensorEntityDescription:
+    """Generate binary sensor description for an environmental digital input."""
+    return BinarySensorEntityDescription(
+        key=f"sensors/devices/{device_id}/channels/digitalInputs/{channel_id}/measures$active",
+        name=f"{channel_name} Contact",
+        translation_key="env_probe_digital_input",
+    )
+
+
+def _generate_env_comm_status_description(
+    device_id: str, device_name: str
+) -> BinarySensorEntityDescription:
+    """Generate binary sensor description for sensor device communication status."""
+    return BinarySensorEntityDescription(
+        key=f"sensors/devices/{device_id}/communicationStatus$state",
+        name=f"{device_name} Communication",
+        translation_key="env_probe_communication",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    )
+
+
 def get_binary_entity_descriptions(
     coordinator: EatonUPSDataUpdateCoordinator,
 ) -> tuple[BinarySensorEntityDescription, ...]:
@@ -276,6 +331,29 @@ def get_binary_entity_descriptions(
             for key in coordinator.data
         ):
             descriptions.extend(_generate_outlet_binary_descriptions(outlet_num))
+
+    # Detect environmental sensor probe channels
+    for key in coordinator.data:
+        match = ENV_DIGITAL_INPUT_PATTERN.match(key)
+        if match:
+            device_id, channel_id = match.groups()
+            channel_name = _get_env_channel_name(
+                coordinator.data, "digitalInputs", device_id, channel_id
+            )
+            descriptions.append(
+                _generate_env_digital_input_description(
+                    device_id, channel_id, channel_name
+                )
+            )
+            continue
+
+        match = ENV_COMM_STATUS_PATTERN.match(key)
+        if match:
+            device_id = match.group(1)
+            device_name = _get_env_device_name(coordinator.data, device_id)
+            descriptions.append(
+                _generate_env_comm_status_description(device_id, device_name)
+            )
 
     return tuple(descriptions)
 
@@ -340,7 +418,7 @@ class EatonUpsBinarySensor(EatonUpsEntity, BinarySensorEntity):
         if isinstance(value, bool):
             return value
         if isinstance(value, str):
-            return value.lower() in ("true", "yes", "on", "1")
+            return value.lower() in ("true", "yes", "on", "1", "ok")
         if isinstance(value, int | float):
             return value > 0
         return False

--- a/custom_components/eaton_ups_mqtt/binary_sensor.py
+++ b/custom_components/eaton_ups_mqtt/binary_sensor.py
@@ -257,13 +257,15 @@ def _generate_outlet_binary_descriptions(
     )
 
 
-ENV_DIGITAL_INPUT_PATTERN = re.compile(
+SENSOR_DIGITAL_INPUT_PATTERN = re.compile(
     r"^sensors/devices/([^/]+)/channels/digitalInputs/([^/]+)/measures$"
 )
-ENV_COMM_STATUS_PATTERN = re.compile(r"^sensors/devices/([^/]+)/communicationStatus$")
+SENSOR_COMM_STATUS_PATTERN = re.compile(
+    r"^sensors/devices/([^/]+)/communicationStatus$"
+)
 
 
-def _get_env_channel_name(
+def _get_sensor_channel_name(
     data: dict[str, Any], channel_type: str, device_id: str, channel_id: str
 ) -> str:
     """Get human-readable channel name from identification topic."""
@@ -277,7 +279,7 @@ def _get_env_channel_name(
     return channel_id
 
 
-def _get_env_device_name(data: dict[str, Any], device_id: str) -> str:
+def _get_sensor_device_name(data: dict[str, Any], device_id: str) -> str:
     """Get human-readable device name from identification topic."""
     id_key = f"sensors/devices/{device_id}/identification"
     id_data = data.get(id_key, {})
@@ -286,25 +288,25 @@ def _get_env_device_name(data: dict[str, Any], device_id: str) -> str:
     return device_id
 
 
-def _generate_env_digital_input_description(
+def _generate_sensor_digital_input_description(
     device_id: str, channel_id: str, channel_name: str
 ) -> BinarySensorEntityDescription:
     """Generate binary sensor description for an environmental digital input."""
     return BinarySensorEntityDescription(
         key=f"sensors/devices/{device_id}/channels/digitalInputs/{channel_id}/measures$active",
         name=f"{channel_name} Contact",
-        translation_key="env_probe_digital_input",
+        translation_key="sensor_digital_input",
     )
 
 
-def _generate_env_comm_status_description(
+def _generate_sensor_comm_status_description(
     device_id: str, device_name: str
 ) -> BinarySensorEntityDescription:
     """Generate binary sensor description for sensor device communication status."""
     return BinarySensorEntityDescription(
         key=f"sensors/devices/{device_id}/communicationStatus$state",
         name=f"{device_name} Communication",
-        translation_key="env_probe_communication",
+        translation_key="sensor_communication",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
     )
@@ -334,25 +336,25 @@ def get_binary_entity_descriptions(
 
     # Detect environmental sensor probe channels
     for key in coordinator.data:
-        match = ENV_DIGITAL_INPUT_PATTERN.match(key)
+        match = SENSOR_DIGITAL_INPUT_PATTERN.match(key)
         if match:
             device_id, channel_id = match.groups()
-            channel_name = _get_env_channel_name(
+            channel_name = _get_sensor_channel_name(
                 coordinator.data, "digitalInputs", device_id, channel_id
             )
             descriptions.append(
-                _generate_env_digital_input_description(
+                _generate_sensor_digital_input_description(
                     device_id, channel_id, channel_name
                 )
             )
             continue
 
-        match = ENV_COMM_STATUS_PATTERN.match(key)
+        match = SENSOR_COMM_STATUS_PATTERN.match(key)
         if match:
             device_id = match.group(1)
-            device_name = _get_env_device_name(coordinator.data, device_id)
+            device_name = _get_sensor_device_name(coordinator.data, device_id)
             descriptions.append(
-                _generate_env_comm_status_description(device_id, device_name)
+                _generate_sensor_comm_status_description(device_id, device_name)
             )
 
     return tuple(descriptions)

--- a/custom_components/eaton_ups_mqtt/diagnostics.py
+++ b/custom_components/eaton_ups_mqtt/diagnostics.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from .coordinator import EatonUPSDataUpdateCoordinator
 
 CONF_TO_REDACT = {CONF_SERVER_CERT, CONF_CLIENT_KEY, CONF_CLIENT_CERT}
-DATA_TO_REDACT = {"serialNumber"}
+DATA_TO_REDACT = {"serialNumber", "serial"}
 
 
 async def async_get_config_entry_diagnostics(

--- a/custom_components/eaton_ups_mqtt/icons.json
+++ b/custom_components/eaton_ups_mqtt/icons.json
@@ -253,10 +253,10 @@
       "outlet_power_quality": {
         "default": "mdi:power-plug"
       },
-      "env_probe_temperature": {
+      "sensor_temperature": {
         "default": "mdi:thermometer"
       },
-      "env_probe_humidity": {
+      "sensor_humidity": {
         "default": "mdi:water-percent"
       }
     },
@@ -369,10 +369,10 @@
       "outlet_switched_on": {
         "default": "mdi:power-socket"
       },
-      "env_probe_digital_input": {
+      "sensor_digital_input": {
         "default": "mdi:electric-switch"
       },
-      "env_probe_communication": {
+      "sensor_communication": {
         "default": "mdi:lan-connect"
       }
     }

--- a/custom_components/eaton_ups_mqtt/icons.json
+++ b/custom_components/eaton_ups_mqtt/icons.json
@@ -252,6 +252,12 @@
       },
       "outlet_power_quality": {
         "default": "mdi:power-plug"
+      },
+      "env_probe_temperature": {
+        "default": "mdi:thermometer"
+      },
+      "env_probe_humidity": {
+        "default": "mdi:water-percent"
       }
     },
     "binary_sensor": {
@@ -362,6 +368,12 @@
       },
       "outlet_switched_on": {
         "default": "mdi:power-socket"
+      },
+      "env_probe_digital_input": {
+        "default": "mdi:electric-switch"
+      },
+      "env_probe_communication": {
+        "default": "mdi:lan-connect"
       }
     }
   }

--- a/custom_components/eaton_ups_mqtt/sensor.py
+++ b/custom_components/eaton_ups_mqtt/sensor.py
@@ -620,15 +620,15 @@ def _generate_outlet_descriptions(
     )
 
 
-ENV_TEMP_PATTERN = re.compile(
+SENSOR_TEMP_PATTERN = re.compile(
     r"^sensors/devices/([^/]+)/channels/temperatures/([^/]+)/measures$"
 )
-ENV_HUMIDITY_PATTERN = re.compile(
+SENSOR_HUMIDITY_PATTERN = re.compile(
     r"^sensors/devices/([^/]+)/channels/humidities/([^/]+)/measures$"
 )
 
 
-def _get_channel_name(
+def _get_sensor_channel_name(
     data: dict[str, Any], channel_type: str, device_id: str, channel_id: str
 ) -> str:
     """Get human-readable channel name from identification topic."""
@@ -642,14 +642,14 @@ def _get_channel_name(
     return channel_id
 
 
-def _generate_env_temperature_description(
+def _generate_sensor_temperature_description(
     device_id: str, channel_id: str, channel_name: str
 ) -> SensorEntityDescription:
     """Generate sensor description for an environmental temperature channel."""
     return SensorEntityDescription(
         key=f"sensors/devices/{device_id}/channels/temperatures/{channel_id}/measures$current",
         name=f"{channel_name} Temperature",
-        translation_key="env_probe_temperature",
+        translation_key="sensor_temperature",
         native_unit_of_measurement=UnitOfTemperature.KELVIN,
         suggested_display_precision=1,
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -657,14 +657,14 @@ def _generate_env_temperature_description(
     )
 
 
-def _generate_env_humidity_description(
+def _generate_sensor_humidity_description(
     device_id: str, channel_id: str, channel_name: str
 ) -> SensorEntityDescription:
     """Generate sensor description for an environmental humidity channel."""
     return SensorEntityDescription(
         key=f"sensors/devices/{device_id}/channels/humidities/{channel_id}/measures$current",
         name=f"{channel_name} Humidity",
-        translation_key="env_probe_humidity",
+        translation_key="sensor_humidity",
         native_unit_of_measurement=PERCENTAGE,
         suggested_display_precision=1,
         device_class=SensorDeviceClass.HUMIDITY,
@@ -736,27 +736,29 @@ def get_entity_descriptions(
 
     # Detect environmental sensor probe channels
     for key in coordinator.data:
-        match = ENV_TEMP_PATTERN.match(key)
+        match = SENSOR_TEMP_PATTERN.match(key)
         if match:
             device_id, channel_id = match.groups()
-            channel_name = _get_channel_name(
+            channel_name = _get_sensor_channel_name(
                 coordinator.data, "temperatures", device_id, channel_id
             )
             descriptions.append(
-                _generate_env_temperature_description(
+                _generate_sensor_temperature_description(
                     device_id, channel_id, channel_name
                 )
             )
             continue
 
-        match = ENV_HUMIDITY_PATTERN.match(key)
+        match = SENSOR_HUMIDITY_PATTERN.match(key)
         if match:
             device_id, channel_id = match.groups()
-            channel_name = _get_channel_name(
+            channel_name = _get_sensor_channel_name(
                 coordinator.data, "humidities", device_id, channel_id
             )
             descriptions.append(
-                _generate_env_humidity_description(device_id, channel_id, channel_name)
+                _generate_sensor_humidity_description(
+                    device_id, channel_id, channel_name
+                )
             )
 
     return tuple(descriptions)

--- a/custom_components/eaton_ups_mqtt/sensor.py
+++ b/custom_components/eaton_ups_mqtt/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -18,6 +19,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfFrequency,
     UnitOfPower,
+    UnitOfTemperature,
     UnitOfTime,
 )
 from homeassistant.helpers.entity import EntityCategory
@@ -618,6 +620,58 @@ def _generate_outlet_descriptions(
     )
 
 
+ENV_TEMP_PATTERN = re.compile(
+    r"^sensors/devices/([^/]+)/channels/temperatures/([^/]+)/measures$"
+)
+ENV_HUMIDITY_PATTERN = re.compile(
+    r"^sensors/devices/([^/]+)/channels/humidities/([^/]+)/measures$"
+)
+
+
+def _get_channel_name(
+    data: dict[str, Any], channel_type: str, device_id: str, channel_id: str
+) -> str:
+    """Get human-readable channel name from identification topic."""
+    id_key = (
+        f"sensors/devices/{device_id}"
+        f"/channels/{channel_type}/{channel_id}/identification"
+    )
+    id_data = data.get(id_key, {})
+    if isinstance(id_data, dict):
+        return id_data.get("name") or id_data.get("physicalName") or channel_id
+    return channel_id
+
+
+def _generate_env_temperature_description(
+    device_id: str, channel_id: str, channel_name: str
+) -> SensorEntityDescription:
+    """Generate sensor description for an environmental temperature channel."""
+    return SensorEntityDescription(
+        key=f"sensors/devices/{device_id}/channels/temperatures/{channel_id}/measures$current",
+        name=f"{channel_name} Temperature",
+        translation_key="env_probe_temperature",
+        native_unit_of_measurement=UnitOfTemperature.KELVIN,
+        suggested_display_precision=1,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+    )
+
+
+def _generate_env_humidity_description(
+    device_id: str, channel_id: str, channel_name: str
+) -> SensorEntityDescription:
+    """Generate sensor description for an environmental humidity channel."""
+    return SensorEntityDescription(
+        key=f"sensors/devices/{device_id}/channels/humidities/{channel_id}/measures$current",
+        name=f"{channel_name} Humidity",
+        translation_key="env_probe_humidity",
+        native_unit_of_measurement=PERCENTAGE,
+        suggested_display_precision=1,
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+    )
+
+
 def get_entity_descriptions(
     coordinator: EatonUPSDataUpdateCoordinator,
 ) -> tuple[SensorEntityDescription, ...]:
@@ -679,6 +733,31 @@ def get_entity_descriptions(
             for key in coordinator.data
         ):
             descriptions.extend(_generate_outlet_descriptions(outlet_num))
+
+    # Detect environmental sensor probe channels
+    for key in coordinator.data:
+        match = ENV_TEMP_PATTERN.match(key)
+        if match:
+            device_id, channel_id = match.groups()
+            channel_name = _get_channel_name(
+                coordinator.data, "temperatures", device_id, channel_id
+            )
+            descriptions.append(
+                _generate_env_temperature_description(
+                    device_id, channel_id, channel_name
+                )
+            )
+            continue
+
+        match = ENV_HUMIDITY_PATTERN.match(key)
+        if match:
+            device_id, channel_id = match.groups()
+            channel_name = _get_channel_name(
+                coordinator.data, "humidities", device_id, channel_id
+            )
+            descriptions.append(
+                _generate_env_humidity_description(device_id, channel_id, channel_name)
+            )
 
     return tuple(descriptions)
 

--- a/custom_components/eaton_ups_mqtt/sensor.py
+++ b/custom_components/eaton_ups_mqtt/sensor.py
@@ -651,6 +651,7 @@ def _generate_sensor_temperature_description(
         name=f"{channel_name} Temperature",
         translation_key="sensor_temperature",
         native_unit_of_measurement=UnitOfTemperature.KELVIN,
+        suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_display_precision=1,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,

--- a/tests/scenario/test_5px_2200_g2_m3.py
+++ b/tests/scenario/test_5px_2200_g2_m3.py
@@ -10,11 +10,16 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescr
 
 from custom_components.eaton_ups_mqtt.binary_sensor import (
     EatonUpsBinarySensor,
+    _get_env_channel_name,
+    _get_env_device_name,
     get_binary_entity_descriptions,
 )
 from custom_components.eaton_ups_mqtt.const import MQTT_PREFIX_V2
 from custom_components.eaton_ups_mqtt.sensor import (
+    ENV_HUMIDITY_PATTERN,
+    ENV_TEMP_PATTERN,
     EatonUpsSensor,
+    _get_channel_name,
     get_entity_descriptions,
 )
 
@@ -124,3 +129,131 @@ class TestM3SpecificValues:
         sensor = EatonUpsSensor(mock_coordinator, desc)
         # M2 returns int (3), M3 returns string ("done")
         assert sensor.native_value == "done"
+
+
+class TestEnvironmentalSensorProbes:
+    """Tests for environmental sensor probe support."""
+
+    def test_temperature_sensor_detected(self, mock_coordinator):
+        """Test that temperature sensor description is generated."""
+        descriptions = get_entity_descriptions(mock_coordinator)
+        temp_keys = [
+            d.key for d in descriptions if ENV_TEMP_PATTERN.match(d.key.split("$")[0])
+        ]
+        assert len(temp_keys) == 1
+
+    def test_humidity_sensor_detected(self, mock_coordinator):
+        """Test that humidity sensor description is generated."""
+        descriptions = get_entity_descriptions(mock_coordinator)
+        humidity_keys = [
+            d.key
+            for d in descriptions
+            if ENV_HUMIDITY_PATTERN.match(d.key.split("$")[0])
+        ]
+        assert len(humidity_keys) == 1
+
+    def test_digital_input_sensors_detected(self, mock_coordinator):
+        """Test that digital input binary sensors are generated."""
+        descriptions = get_binary_entity_descriptions(mock_coordinator)
+        di_keys = [d.key for d in descriptions if "channels/digitalInputs/" in d.key]
+        assert len(di_keys) == 2
+
+    def test_communication_status_detected(self, mock_coordinator):
+        """Test that communication status binary sensor is generated."""
+        descriptions = get_binary_entity_descriptions(mock_coordinator)
+        comm_keys = [d.key for d in descriptions if "communicationStatus" in d.key]
+        assert len(comm_keys) == 1
+
+    def test_temperature_value(self, mock_coordinator):
+        """Test temperature sensor reads Kelvin value correctly."""
+        descriptions = get_entity_descriptions(mock_coordinator)
+        temp_desc = next(
+            d for d in descriptions if ENV_TEMP_PATTERN.match(d.key.split("$")[0])
+        )
+        sensor = EatonUpsSensor(mock_coordinator, temp_desc)
+        assert sensor.native_value == pytest.approx(301.049988)
+
+    def test_humidity_value(self, mock_coordinator):
+        """Test humidity sensor reads value correctly."""
+        descriptions = get_entity_descriptions(mock_coordinator)
+        humidity_desc = next(
+            d for d in descriptions if ENV_HUMIDITY_PATTERN.match(d.key.split("$")[0])
+        )
+        sensor = EatonUpsSensor(mock_coordinator, humidity_desc)
+        assert sensor.native_value == pytest.approx(14.3000002)
+
+    def test_digital_input_values(self, mock_coordinator):
+        """Test digital input binary sensors read correctly."""
+        descriptions = get_binary_entity_descriptions(mock_coordinator)
+        di_descs = [d for d in descriptions if "channels/digitalInputs/" in d.key]
+        for desc in di_descs:
+            sensor = EatonUpsBinarySensor(mock_coordinator, desc)
+            assert sensor.is_on is False
+
+    def test_communication_status_value(self, mock_coordinator):
+        """Test communication status reads 'ok' as True."""
+        descriptions = get_binary_entity_descriptions(mock_coordinator)
+        comm_desc = next(d for d in descriptions if "communicationStatus" in d.key)
+        sensor = EatonUpsBinarySensor(mock_coordinator, comm_desc)
+        assert sensor.is_on is True
+
+    def test_temperature_sensor_name(self, mock_coordinator):
+        """Test temperature sensor uses channel identification name."""
+        descriptions = get_entity_descriptions(mock_coordinator)
+        temp_desc = next(
+            d for d in descriptions if ENV_TEMP_PATTERN.match(d.key.split("$")[0])
+        )
+        assert temp_desc.name == "SI-NW-UV-1@1-T1 Temperature"
+
+    def test_humidity_sensor_name(self, mock_coordinator):
+        """Test humidity sensor uses channel identification name."""
+        descriptions = get_entity_descriptions(mock_coordinator)
+        humidity_desc = next(
+            d for d in descriptions if ENV_HUMIDITY_PATTERN.match(d.key.split("$")[0])
+        )
+        assert humidity_desc.name == "SI-NW-UV-1@1-H1 Humidity"
+
+    def test_digital_input_sensor_names(self, mock_coordinator):
+        """Test digital input sensors use channel identification names."""
+        descriptions = get_binary_entity_descriptions(mock_coordinator)
+        di_descs = [d for d in descriptions if "channels/digitalInputs/" in d.key]
+        names = sorted(d.name for d in di_descs)
+        assert names == ["SI-NW-UV-1@1-C1 Contact", "SI-NW-UV-1@1-C2 Contact"]
+
+    def test_communication_status_name(self, mock_coordinator):
+        """Test communication status uses device identification name."""
+        descriptions = get_binary_entity_descriptions(mock_coordinator)
+        comm_desc = next(d for d in descriptions if "communicationStatus" in d.key)
+        assert comm_desc.name == "SI-NW-UV-1 Communication"
+
+
+class TestEnvProbeNameFallbacks:
+    """Tests for name lookup fallbacks when identification data is missing."""
+
+    def test_sensor_channel_name_fallback_non_dict(self):
+        """Test _get_channel_name returns channel_id when data is not a dict."""
+        data = {
+            "sensors/devices/dev1/channels/temperatures/ch1/identification": None,
+        }
+        assert _get_channel_name(data, "temperatures", "dev1", "ch1") == "ch1"
+
+    def test_sensor_channel_name_fallback_missing(self):
+        """Test _get_channel_name returns channel_id when key is missing."""
+        assert _get_channel_name({}, "temperatures", "dev1", "ch1") == "ch1"
+
+    def test_binary_sensor_channel_name_fallback_non_dict(self):
+        """Test _get_env_channel_name returns channel_id for non-dict data."""
+        data = {
+            "sensors/devices/dev1/channels/digitalInputs/ch1/identification": None,
+        }
+        result = _get_env_channel_name(data, "digitalInputs", "dev1", "ch1")
+        assert result == "ch1"
+
+    def test_binary_sensor_device_name_fallback_non_dict(self):
+        """Test _get_env_device_name returns device_id for non-dict data."""
+        data = {"sensors/devices/dev1/identification": None}
+        assert _get_env_device_name(data, "dev1") == "dev1"
+
+    def test_binary_sensor_device_name_fallback_missing(self):
+        """Test _get_env_device_name returns device_id when key is missing."""
+        assert _get_env_device_name({}, "dev1") == "dev1"

--- a/tests/scenario/test_5px_2200_g2_m3.py
+++ b/tests/scenario/test_5px_2200_g2_m3.py
@@ -8,18 +8,17 @@ from unittest.mock import MagicMock
 import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
 
+from custom_components.eaton_ups_mqtt import binary_sensor as bs
+from custom_components.eaton_ups_mqtt import sensor as s
 from custom_components.eaton_ups_mqtt.binary_sensor import (
     EatonUpsBinarySensor,
-    _get_env_channel_name,
-    _get_env_device_name,
     get_binary_entity_descriptions,
 )
 from custom_components.eaton_ups_mqtt.const import MQTT_PREFIX_V2
 from custom_components.eaton_ups_mqtt.sensor import (
-    ENV_HUMIDITY_PATTERN,
-    ENV_TEMP_PATTERN,
+    SENSOR_HUMIDITY_PATTERN,
+    SENSOR_TEMP_PATTERN,
     EatonUpsSensor,
-    _get_channel_name,
     get_entity_descriptions,
 )
 
@@ -138,7 +137,9 @@ class TestEnvironmentalSensorProbes:
         """Test that temperature sensor description is generated."""
         descriptions = get_entity_descriptions(mock_coordinator)
         temp_keys = [
-            d.key for d in descriptions if ENV_TEMP_PATTERN.match(d.key.split("$")[0])
+            d.key
+            for d in descriptions
+            if SENSOR_TEMP_PATTERN.match(d.key.split("$")[0])
         ]
         assert len(temp_keys) == 1
 
@@ -148,7 +149,7 @@ class TestEnvironmentalSensorProbes:
         humidity_keys = [
             d.key
             for d in descriptions
-            if ENV_HUMIDITY_PATTERN.match(d.key.split("$")[0])
+            if SENSOR_HUMIDITY_PATTERN.match(d.key.split("$")[0])
         ]
         assert len(humidity_keys) == 1
 
@@ -168,7 +169,7 @@ class TestEnvironmentalSensorProbes:
         """Test temperature sensor reads Kelvin value correctly."""
         descriptions = get_entity_descriptions(mock_coordinator)
         temp_desc = next(
-            d for d in descriptions if ENV_TEMP_PATTERN.match(d.key.split("$")[0])
+            d for d in descriptions if SENSOR_TEMP_PATTERN.match(d.key.split("$")[0])
         )
         sensor = EatonUpsSensor(mock_coordinator, temp_desc)
         assert sensor.native_value == pytest.approx(301.049988)
@@ -177,7 +178,9 @@ class TestEnvironmentalSensorProbes:
         """Test humidity sensor reads value correctly."""
         descriptions = get_entity_descriptions(mock_coordinator)
         humidity_desc = next(
-            d for d in descriptions if ENV_HUMIDITY_PATTERN.match(d.key.split("$")[0])
+            d
+            for d in descriptions
+            if SENSOR_HUMIDITY_PATTERN.match(d.key.split("$")[0])
         )
         sensor = EatonUpsSensor(mock_coordinator, humidity_desc)
         assert sensor.native_value == pytest.approx(14.3000002)
@@ -201,7 +204,7 @@ class TestEnvironmentalSensorProbes:
         """Test temperature sensor uses channel identification name."""
         descriptions = get_entity_descriptions(mock_coordinator)
         temp_desc = next(
-            d for d in descriptions if ENV_TEMP_PATTERN.match(d.key.split("$")[0])
+            d for d in descriptions if SENSOR_TEMP_PATTERN.match(d.key.split("$")[0])
         )
         assert temp_desc.name == "SI-NW-UV-1@1-T1 Temperature"
 
@@ -209,7 +212,9 @@ class TestEnvironmentalSensorProbes:
         """Test humidity sensor uses channel identification name."""
         descriptions = get_entity_descriptions(mock_coordinator)
         humidity_desc = next(
-            d for d in descriptions if ENV_HUMIDITY_PATTERN.match(d.key.split("$")[0])
+            d
+            for d in descriptions
+            if SENSOR_HUMIDITY_PATTERN.match(d.key.split("$")[0])
         )
         assert humidity_desc.name == "SI-NW-UV-1@1-H1 Humidity"
 
@@ -227,33 +232,35 @@ class TestEnvironmentalSensorProbes:
         assert comm_desc.name == "SI-NW-UV-1 Communication"
 
 
-class TestEnvProbeNameFallbacks:
+class TestSensorNameFallbacks:
     """Tests for name lookup fallbacks when identification data is missing."""
 
     def test_sensor_channel_name_fallback_non_dict(self):
-        """Test _get_channel_name returns channel_id when data is not a dict."""
+        """Test sensor _get_sensor_channel_name returns channel_id for non-dict."""
         data = {
             "sensors/devices/dev1/channels/temperatures/ch1/identification": None,
         }
-        assert _get_channel_name(data, "temperatures", "dev1", "ch1") == "ch1"
+        result = s._get_sensor_channel_name(data, "temperatures", "dev1", "ch1")
+        assert result == "ch1"
 
     def test_sensor_channel_name_fallback_missing(self):
-        """Test _get_channel_name returns channel_id when key is missing."""
-        assert _get_channel_name({}, "temperatures", "dev1", "ch1") == "ch1"
+        """Test sensor _get_sensor_channel_name returns channel_id when missing."""
+        result = s._get_sensor_channel_name({}, "temperatures", "dev1", "ch1")
+        assert result == "ch1"
 
     def test_binary_sensor_channel_name_fallback_non_dict(self):
-        """Test _get_env_channel_name returns channel_id for non-dict data."""
+        """Test binary_sensor _get_sensor_channel_name returns channel_id for non-dict."""
         data = {
             "sensors/devices/dev1/channels/digitalInputs/ch1/identification": None,
         }
-        result = _get_env_channel_name(data, "digitalInputs", "dev1", "ch1")
+        result = bs._get_sensor_channel_name(data, "digitalInputs", "dev1", "ch1")
         assert result == "ch1"
 
     def test_binary_sensor_device_name_fallback_non_dict(self):
-        """Test _get_env_device_name returns device_id for non-dict data."""
+        """Test _get_sensor_device_name returns device_id for non-dict data."""
         data = {"sensors/devices/dev1/identification": None}
-        assert _get_env_device_name(data, "dev1") == "dev1"
+        assert bs._get_sensor_device_name(data, "dev1") == "dev1"
 
     def test_binary_sensor_device_name_fallback_missing(self):
-        """Test _get_env_device_name returns device_id when key is missing."""
-        assert _get_env_device_name({}, "dev1") == "dev1"
+        """Test _get_sensor_device_name returns device_id when key is missing."""
+        assert bs._get_sensor_device_name({}, "dev1") == "dev1"

--- a/tests/scenario/test_5px_g2.py
+++ b/tests/scenario/test_5px_g2.py
@@ -8,7 +8,14 @@ from unittest.mock import MagicMock
 import pytest
 from homeassistant.components.sensor import SensorEntityDescription
 
-from custom_components.eaton_ups_mqtt.sensor import EatonUpsSensor
+from custom_components.eaton_ups_mqtt.binary_sensor import (
+    get_binary_entity_descriptions,
+)
+from custom_components.eaton_ups_mqtt.const import MQTT_PREFIX_V1
+from custom_components.eaton_ups_mqtt.sensor import (
+    EatonUpsSensor,
+    get_entity_descriptions,
+)
 
 
 @pytest.fixture
@@ -16,6 +23,7 @@ def mock_coordinator(ups_5px_g2_data):
     """Create a mock coordinator with 5PX G2 fixture data."""
     coordinator = MagicMock()
     coordinator.config_entry.entry_id = "test_5px_g2"
+    coordinator.config_entry.runtime_data.client.mqtt_prefix = MQTT_PREFIX_V1
     coordinator.data = ups_5px_g2_data
     return coordinator
 
@@ -342,3 +350,19 @@ class TestSpecifications:
         desc = SensorEntityDescription(key=key, name="Test")
         sensor = EatonUpsSensor(mock_coordinator, desc)
         assert sensor.native_value == {"nominal": 1500}
+
+
+class TestNoEnvironmentalSensorProbes:
+    """Verify M2 fixture without sensor probes produces no env probe entities."""
+
+    def test_no_env_probe_sensors(self, mock_coordinator):
+        """Test M2 data without sensor probes generates no env probe sensors."""
+        descriptions = get_entity_descriptions(mock_coordinator)
+        env_keys = [d.key for d in descriptions if d.key.startswith("sensors/")]
+        assert env_keys == []
+
+    def test_no_env_probe_binary_sensors(self, mock_coordinator):
+        """Test M2 data without sensor probes generates no env probe binary sensors."""
+        descriptions = get_binary_entity_descriptions(mock_coordinator)
+        env_keys = [d.key for d in descriptions if d.key.startswith("sensors/")]
+        assert env_keys == []


### PR DESCRIPTION
## Summary
- Subscribe to `sensors/#` MQTT topics to receive sensor device data
- Dynamically create temperature (Kelvin, auto-converted by HA), humidity, and dry contact entities for sensor devices (e.g. Eaton EMPDT1H1C2) connected to Network-M2/M3 cards
- Add per-device communication status binary sensor
- Entity names are derived from channel identification data (e.g. "SI-NW-UV-1@1-T1 Temperature")
- Redact `serial` field in diagnostics (sensor devices use `serial` instead of `serialNumber`)

## Test plan
- [x] All 300 tests pass
- [x] 100% diff coverage
- [x] Ruff format + lint clean
- [x] ty type check clean
- [ ] Manual verification with M3 device running sensor probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)