### PR TITLE
Disconnect MQTT client on Home Assistant stop

### DIFF
--- a/custom_components/eaton_ups_mqtt/__init__.py
+++ b/custom_components/eaton_ups_mqtt/__init__.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+    EVENT_HOMEASSISTANT_STOP,
+    Platform,
+)
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.issue_registry import (
@@ -42,7 +47,7 @@ from .coordinator import EatonUPSDataUpdateCoordinator
 from .data import EatonUpsData
 
 if TYPE_CHECKING:
-    from homeassistant.core import HomeAssistant
+    from homeassistant.core import Event, HomeAssistant
 
     from .data import EatonUpsConfigEntry
 
@@ -120,6 +125,16 @@ async def async_setup_entry(
         client=EatonUpsMqttClient(config=config, session=async_get_clientsession(hass)),
         integration=async_get_loaded_integration(hass, entry.domain),
         coordinator=coordinator,
+    )
+
+    # Config entries are not unloaded on Home Assistant stop, so the coordinator's
+    # unload-time disconnect never runs. Without this the paho network thread keeps
+    # delivering messages to the closed event loop, raising "Event loop is closed".
+    async def _async_disconnect_on_stop(_event: Event) -> None:
+        await entry.runtime_data.client.async_disconnect()
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_disconnect_on_stop)
     )
 
     try:

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -320,6 +320,36 @@ class TestReloadEntry:
         await hass.async_block_till_done()
 
         assert mock_entry.state == ConfigEntryState.LOADED
+
+
+class TestStopDisconnect:
+    """Tests for disconnecting MQTT when Home Assistant stops."""
+
+    async def test_mqtt_disconnects_on_hass_stop(
+        self,
+        hass: HomeAssistant,
+        mock_entry,
+        mock_mqtt_setup,
+    ):
+        """Test that the MQTT client is disconnected on Home Assistant stop.
+
+        Config entries are not unloaded on Home Assistant stop, so the
+        coordinator's unload-time disconnect does not run. The component
+        registers its own stop handler so the paho network thread is stopped
+        before the event loop closes.
+        """
+        mock_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert mock_entry.state == ConfigEntryState.LOADED
+        mock_mqtt_setup.async_disconnect.assert_not_called()
+
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+        mock_mqtt_setup.async_disconnect.assert_called_once()
 
 
 class TestClientCertFile:


### PR DESCRIPTION
## Summary

Config entries are not unloaded when Home Assistant stops, so the coordinator's unload-time disconnect (registered via `async_on_unload`) never runs on shutdown. The paho network thread started by `loop_start()` keeps delivering messages after the event loop is closed, so every restart produces a burst of errors, one per MQTT message in flight during the shutdown window:

```
ERROR (paho-mqtt-client-...) [custom_components.eaton_ups_mqtt.api] Error processing MQTT message
Traceback (most recent call last):
  File ".../custom_components/eaton_ups_mqtt/api.py", line 319, in _on_message
    self._loop.call_soon_threadsafe(...)
  File ".../asyncio/base_events.py", line 550, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```

This registers an `EVENT_HOMEASSISTANT_STOP` listener that disconnects the MQTT client, stopping the network thread before the loop closes. Reload and unload already disconnect via the coordinator's `async_on_unload`, so this only adds the missing stop path.

## Test plan

- [x] New `test_mqtt_disconnects_on_hass_stop` asserts `async_disconnect` is called when `EVENT_HOMEASSISTANT_STOP` fires
- [x] `uv run pytest` (301 passed)
- [x] `uv run ruff check .` and `uv run ruff format . --check`
- [x] `uv run ty check`
- [x] Verified on a live instance: under active MQTT traffic, a restart now logs a single clean "Normal disconnection" with zero "Event loop is closed" errors