### PR TITLE
Disconnect MQTT client on Home Assistant stop

### DIFF
--- a/custom_components/eaton_ups_mqtt/__init__.py
+++ b/custom_components/eaton_ups_mqtt/__init__.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+    EVENT_HOMEASSISTANT_STOP,
+    Platform,
+)
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.issue_registry import (
@@ -42,7 +47,7 @@ from .coordinator import EatonUPSDataUpdateCoordinator
 from .data import EatonUpsData
 
 if TYPE_CHECKING:
-    from homeassistant.core import HomeAssistant
+    from homeassistant.core import Event, HomeAssistant
 
     from .data import EatonUpsConfigEntry
 
@@ -120,6 +125,13 @@ async def async_setup_entry(
         client=EatonUpsMqttClient(config=config, session=async_get_clientsession(hass)),
         integration=async_get_loaded_integration(hass, entry.domain),
         coordinator=coordinator,
+    )
+
+    async def _async_disconnect_on_stop(_event: Event) -> None:
+        await entry.runtime_data.client.async_disconnect()
+
+    entry.async_on_unload(
+        hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, _async_disconnect_on_stop)
     )
 
     try:

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -320,6 +320,30 @@ class TestReloadEntry:
         await hass.async_block_till_done()
 
         assert mock_entry.state == ConfigEntryState.LOADED
+
+
+class TestStopDisconnect:
+    """Tests for disconnecting MQTT when Home Assistant stops."""
+
+    async def test_mqtt_disconnects_on_hass_stop(
+        self,
+        hass: HomeAssistant,
+        mock_entry,
+        mock_mqtt_setup,
+    ):
+        """Test that the MQTT client is disconnected on Home Assistant stop."""
+        mock_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert mock_entry.state == ConfigEntryState.LOADED
+        mock_mqtt_setup.async_disconnect.assert_not_called()
+
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+        mock_mqtt_setup.async_disconnect.assert_called_once()
 
 
 class TestClientCertFile:


### PR DESCRIPTION
## Summary

Config entries are not unloaded on Home Assistant stop (`ConfigEntry.async_shutdown` only cancels retry setup; it does not call `async_unload`), so the coordinator's unload-time disconnect — registered via `async_on_unload` — never runs during shutdown. The paho network thread started by `loop_start()` keeps delivering messages after the event loop is closed, producing one `RuntimeError: Event loop is closed` per in-flight MQTT message:

```
ERROR (paho-mqtt-client-...) [custom_components.eaton_ups_mqtt.api] Error processing MQTT message
Traceback (most recent call last):
  File ".../api.py", line 319, in _on_message
    self._loop.call_soon_threadsafe(...)
  File ".../asyncio/base_events.py", line 550, in _check_closed
    raise RuntimeError('Event loop is closed')
```

Register an `EVENT_HOMEASSISTANT_STOP` listener that disconnects the MQTT client, stopping the paho network thread before the loop closes. The listener is wrapped in `entry.async_on_unload(...)` so reload paths clean it up. Unload/reload are still handled by the coordinator's existing `async_shutdown`, so no double-disconnect.

Follows the canonical HA core pattern used by `homeassistant/components/mqtt/client.py` ([`client.py:461-466`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/mqtt/client.py#L461-L466)): `hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, ...)` tied to the entry's unload lifecycle.

Closes #89 (alternative implementation — thanks to @pszypowicz for diagnosing the issue and prototyping the fix).

## Test plan

- [x] New `test_mqtt_disconnects_on_hass_stop` asserts `async_disconnect` is called when `EVENT_HOMEASSISTANT_STOP` fires
- [x] `uv run pytest` — 301 passed
- [x] `uv run ruff format .` / `uv run ruff check .` / `uv run ty check` — all clean
- [x] Live restart on real HA instance: one clean `Normal disconnection (server_sent=False)` line, zero `Event loop is closed` errors
- [x] Two consecutive UI reloads: each cycle shows exactly one clean disconnect (matching the previous client's thread UUID) followed by a fresh connect — no leaked threads, no double-disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)