### PR TITLE
Declare paho-mqtt in manifest requirements

### DIFF
--- a/custom_components/eaton_ups_mqtt/manifest.json
+++ b/custom_components/eaton_ups_mqtt/manifest.json
@@ -15,5 +15,8 @@
   "loggers": [
     "paho"
   ],
+  "requirements": [
+    "paho-mqtt>=2.1.0"
+  ],
   "version": "0.5.0"
 }


### PR DESCRIPTION
`api.py` imports `paho.mqtt.client` at module level but the manifest declared no `requirements`. It works today because `dependencies: ["mqtt"]` means core installs paho-mqtt anyway — but that is setup ordering, not a package guarantee, and it leaves the `>=2.1.0` floor in `pyproject.toml` unenforced.

Adds `paho-mqtt>=2.1.0` to `manifest.json` requirements.