### PR TITLE
Stop dependabot rewriting pyproject.toml on every dependency bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: increase-if-necessary
+    groups:
+      home-assistant-test-stack:
+        patterns:
+          - "pytest-homeassistant-custom-component"
+      dev-tooling:
+        dependency-type: "development"
+        exclude-patterns:
+          - "pytest-homeassistant-custom-component"
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "homeassistant"
       - dependency-name: "pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,21 +9,20 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.14.2"
 dependencies = [
-    "colorlog>=6.10.1",
     "homeassistant>=2026.3.0",
     "paho-mqtt>=2.1.0",
 ]
 
 [dependency-groups]
 dev = [
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.20.0",
-    "pytest-cov>=4.0.0",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
     "pytest-homeassistant-custom-component==0.13.355",
-    "bump-my-version>=1.5.1",
-    "diff-cover>=9.0.0",
-    "ruff>=0.16.2",
-    "ty>=0.0.69",
+    "bump-my-version",
+    "diff-cover",
+    "ruff",
+    "ty",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -725,18 +725,6 @@ wheels = [
 ]
 
 [[package]]
-name = "colorlog"
-version = "6.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/55/ba79756cb90c8d69d599d57785398ac87bba7b19c80e87f4e8a562197c93/colorlog-6.12.0.tar.gz", hash = "sha256:2a7924c1dadf18b22a0eb8b06d1c7b01d5341707ec1641eb6fcc4fde0c3e8e5f", size = 18151, upload-time = "2026-07-23T13:40:40.71Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/19/0b6647bf5e331521e55d2b63bfbdc210bd9cd605189273f03614a05f702d/colorlog-6.12.0-py3-none-any.whl", hash = "sha256:30d392604e9110045a2c2aeefc27d7a017abbab63f3a8aee594eac0801df784e", size = 12239, upload-time = "2026-07-23T13:40:39.562Z" },
-]
-
-[[package]]
 name = "coverage"
 version = "7.15.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1089,7 +1077,6 @@ name = "hass-eaton-ups-mqtt"
 version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "colorlog" },
     { name = "homeassistant" },
     { name = "paho-mqtt" },
 ]
@@ -1108,21 +1095,20 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "colorlog", specifier = ">=6.10.1" },
     { name = "homeassistant", specifier = ">=2026.3.0" },
     { name = "paho-mqtt", specifier = ">=2.1.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "bump-my-version", specifier = ">=1.5.1" },
-    { name = "diff-cover", specifier = ">=9.0.0" },
-    { name = "pytest", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.20.0" },
-    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "bump-my-version" },
+    { name = "diff-cover" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.355" },
-    { name = "ruff", specifier = ">=0.16.2" },
-    { name = "ty", specifier = ">=0.0.69" },
+    { name = "ruff" },
+    { name = "ty" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Dependabot's uv ecosystem defaults to `versioning-strategy: increase`, so every dev-tool bump rewrote that tool's lower bound in `pyproject.toml` **and** the mirrored specifier in `uv.lock`'s `[package.metadata]` block:

```diff
-    "ruff>=0.16.1",
+    "ruff>=0.16.2",
```

The four dependabot-managed tools (`ruff`, `ty`, `bump-my-version`, `diff-cover`) sit within a five-line window of each other in both files. Git's 3-line context means merging any one PR immediately invalidated the other three — hence the weekly rebase ritual across four repos.

## Fix

**`versioning-strategy: increase-if-necessary`** — only rewrites a specifier when the new version wouldn't otherwise satisfy it. With `>=` floors that never happens, so routine tooling bumps become **lock-only diffs**, touching well-separated `[[package]]` stanzas that merge cleanly.

This also closes a latent drift bug: under `increase`, a `pymodbus`/`paho-mqtt`/`aiohttp` bump would raise the floor in `pyproject.toml` while silently leaving `manifest.json` — the file Home Assistant actually reads — at the old floor.

**Grouping** — dev tooling collapses into one weekly PR. `pytest-homeassistant-custom-component` gets its own group rather than being bundled in: it pins the HA version and the whole test stack, making it the one bump that can legitimately fail CI. Separate means it's reviewed on its own and can sit red without blocking routine tool updates. It is deliberately **not** in `ignore`, so it still gets its own dependabot PRs.

**Dropped the dev-tool version floors.** These repos set `package = false` and ship runtime requirements via `manifest.json`, so nothing consumes this metadata and `uv.lock` alone decides what CI runs. The floors carried no information — `pytest>=7.0.0` when phcc pins it far higher, `ty>=0.0.69` for a `0.0.x` tool — and only generated churn. Kept: the phcc `==` pin and the runtime floors that mirror `manifest.json`.

**Removed `colorlog`**, declared as a runtime dependency but referenced in zero files across all repos — leftover from `integration_blueprint`.

## Verification

`uv lock` produced **no package version changes** in any repo — the only lockfile deltas are the removed `colorlog` stanza and the dropped specifier strings. Test suite passes locally (410 passed, 4 skipped on komfovent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4J3dxHPjuNbfkqibVYunB
